### PR TITLE
Better form validation

### DIFF
--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -5,21 +5,26 @@
     <%%= form.label :<%= attribute.column_name %> %>
 <% end -%>
 <% if attribute.reference? -%>
-    <%%= form.collection_select(:<%= attribute.column_name %>, <%= attribute.name.camelize %>.all, :id, :to_s, {}, { class: 'form-control', data: { controller: 'select' } }) %>
+    <%%= form.collection_select(:<%= attribute.column_name %>, <%= attribute.name.camelize %>.all, :id, :to_s, {}, { class: "form-control #{'is-invalid' if <%= model_resource_name %>.errors[:<%= attribute.column_name %>].present?}", data: { controller: 'select' } }) %>
 <% elsif attribute.field_type == :check_box -%>
     <div class="custom-control custom-checkbox">
       <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: 'custom-control-input' %>
       <%%= form.label :<%= attribute.column_name %>, class: 'custom-control-label' %>
     </div>
 <% elsif %i(date datetime).include?(attribute.type) -%>
-    <%%= form.text_field :<%= attribute.column_name %>, value: l(<%= model_resource_name %>.<%= attribute.column_name %>), class: 'form-control', data: { controller: '<%= attribute.type %>' } %>
+    <%%= form.text_field :<%= attribute.column_name %>, value: l(<%= model_resource_name %>.<%= attribute.column_name %>), class: "form-control #{'is-invalid' if <%= model_resource_name %>.errors[:<%= attribute.column_name %>].present?}", data: { controller: '<%= attribute.type %>' } %>
 <% elsif %i(time).include?(attribute.type) -%>
-    <%%= form.text_field :<%= attribute.column_name %>, value: l(<%= model_resource_name %>.<%= attribute.column_name %>, format: :time), class: 'form-control', data: { controller: 'time' } %>
+    <%%= form.text_field :<%= attribute.column_name %>, value: l(<%= model_resource_name %>.<%= attribute.column_name %>, format: :time), class: "form-control #{'is-invalid' if <%= model_resource_name %>.errors[:<%= attribute.column_name %>].present?}", data: { controller: 'time' } %>
 <% elsif %i(float decimal).include?(attribute.type) -%>
-    <%%= form.number_field :<%= attribute.column_name %>, step: :any, class: 'form-control' %>
+    <%%= form.number_field :<%= attribute.column_name %>, step: :any, class: "form-control #{'is-invalid' if <%= model_resource_name %>.errors[:<%= attribute.column_name %>].present?}" %>
 <% else -%>
-    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: 'form-control' %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "form-control #{'is-invalid' if <%= model_resource_name %>.errors[:<%= attribute.column_name %>].present?}" %>
 <% end -%>
+    <%% if <%= model_resource_name %>.errors[:<%= attribute.column_name %>].present? %>
+      <div class="invalid-feedback">
+        <%%= <%= model_resource_name %>.errors[:<%= attribute.column_name %>].to_sentence.humanize %>
+      </div>
+    <%% end %>
   </div>
 <% end -%>
   <div class="card-footer pl-0">

--- a/lib/templates/rails/scaffold_controller/controller.rb
+++ b/lib/templates/rails/scaffold_controller/controller.rb
@@ -28,19 +28,26 @@ class <%= controller_class_name %>Controller < ApplicationController
 
   def create
     @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
-    @<%= singular_table_name %>.save!
-
     respond_to do |format|
-      format.html { redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %> }
-      format.json { render :show, status: :created }
+      if @<%= singular_table_name %>.save
+        format.html { redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %> }
+        format.json { render :show, status: :created }
+      else
+        format.html { render :new }
+        format.json { render json: @<%= singular_table_name %>.errors, status: :unprocessable_entity }
+      end
     end
   end
 
   def update
-    @<%= singular_table_name %>.update!(<%= "#{singular_table_name}_params" %>)
     respond_to do |format|
-      format.html { redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %> }
-      format.json { render :show }
+      if @<%= singular_table_name %>.update(<%= "#{singular_table_name}_params" %>)
+        format.html { redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %> }
+        format.json { render :show }
+      else
+        format.html { render :edit }
+        format.json { render json: @<%= singular_table_name %>.errors, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/template.rb
+++ b/template.rb
@@ -6,6 +6,7 @@ gem 'ransack'
 gem 'platform_agent'
 gem 'geared_pagination'
 gem 'spreadsheet_architect'
+gem 'turbolinks_render'
 
 gem_group :production do
   gem 'redis'


### PR DESCRIPTION
This PR updates the controller and form template so that validation errors are rendered on the screen like this.

<img width="734" alt="Screen Shot 2020-03-21 at 3 49 53 PM" src="https://user-images.githubusercontent.com/78157/77223114-4bd40100-6b8c-11ea-8d72-61418b744fa3.png">

It works by including the https://github.com/jorgemanrubia/turbolinks_render gem, this gem makes it so that HTML returned from a POST request will be rendered by Turbolinks.

I have then updated the controller template to set the errors and I've updated the form template to display the errors inline.